### PR TITLE
:bug: fix middleware

### DIFF
--- a/server/middlewares/index.js
+++ b/server/middlewares/index.js
@@ -7,11 +7,13 @@ module.exports = {
   metrics: ({ strapi }) => {
     const { config, service } = strapi.plugin(plugin_id);
     const metrics = service('metrics');
+    const isHTTPMetricEnabled = config('enabledMetrics.http');
 
     return async (ctx, next) => {
       const requestEnd = metrics.get(metricNames.HTTP.requestDuration)?.startTimer({ method: ctx.method });
       await next();
 
+      if (!isHTTPMetricEnabled) return;
       ctx.res.once('finish', () => {
         if (ctx._matchedRoute === `${strapi.config.api.rest.prefix}/metrics`) return;
         let path = `${config('fullURL') ? ctx.url.split('?')[0] : ctx._matchedRoute || '/'}`;


### PR DESCRIPTION
Pull Request Description:

**Issue**
This pull request addresses the bug reported in issue #16. When the `enabledMetrics.http` configuration option is set to `false`, certain metrics (`requestDuration`, `requestSize`, `responseSize`) are still being collected, resulting in an error.

**Changes Made**
In the `app/config/plugins.js` file, I have made the following changes to fix the bug:
- Introduced a new variable `isHTTPMetricEnabled` to store the value of `config('enabledMetrics.http')`.
- Added a conditional check `if (!isHTTPMetricEnabled) return;` to exit the middleware if HTTP metrics are disabled.
- This ensures that the metrics collection code is bypassed when `enabledMetrics.http` is set to `false`, preventing the error from occurring.

**Testing**
I have tested the changes by following the steps mentioned in the issue description. After applying this fix, I confirmed that the error no longer occurs when accessing endpoints, and no metrics are collected when `enabledMetrics.http` is set to `false`.

This pull request resolves the bug and improves the behavior of the metrics collection feature when HTTP metrics are disabled.