### PR TITLE
feat(metrics): add flexible path normalization config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ yarn-error.log
 coverage
 
 .yalc
+
+yalc.lock

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ module.exports = {
       
       // 🎯 Path Normalization Rules
       normalize: [
-        [/[a-z0-9]{24,25}|\d/, ':id'], // Document IDs or numeric IDs
+        [/\/[a-z0-9]{24,25}|\d+/, '/:id'], // Document IDs or numeric IDs
         [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file'], // Uploaded files with extensions
       ]
     }

--- a/README.md
+++ b/README.md
@@ -74,21 +74,8 @@ module.exports = {
       
       // 🎯 Path Normalization Rules
       normalize: [
-        // Strapi API routes
-        [/^\/api\/([^\/]+)\/([^\/]+)$/, '/api/$1/:id'],                    // /api/posts/123
-        [/^\/api\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/api/$1/:id/$3'],       // /api/posts/123/comments
-        [/^\/api\/([^\/]+)\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/api/$1/$2/:id/$4'], // /api/posts/123/comments/456
-        
-        // i18n locale routes
-        [/^\/([a-z]{2}(-[A-Z]{2})?)\/api\/([^\/]+)\/([^\/]+)$/, '/$1/api/$3/:id'],
-        [/^\/([a-z]{2}(-[A-Z]{2})?)\//, '/:locale/'],
-        
-        // Admin routes
-        [/^\/admin\/content-manager\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/admin/content-manager/$1/:contentType/:id'],
-        [/^\/admin\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/admin/$1/:type/:id'],
-        
-        // Upload routes
-        [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file']
+        [/[a-z0-9]{24,25}|\d/, ':id'], // Document IDs or numeric IDs
+        [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file'], // Uploaded files with extensions
       ]
     }
   }
@@ -169,15 +156,8 @@ Use an array of `[RegExp, replacement]` tuples to define normalization patterns:
 
 ```js
 normalize: [
-  // Strapi API routes
-  [/^\/api\/([^\/]+)\/([^\/]+)$/, '/api/$1/:id'],                    // /api/posts/123
-  [/^\/api\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/api/$1/:id/$3'],       // /api/posts/123/comments
-  
-  // Admin routes
-  [/^\/admin\/content-manager\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/admin/content-manager/$1/:contentType/:id'],
-  
-  // Upload routes
-  [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file'],
+  [/[a-z0-9]{24,25}|\d/, ':id'], // Document IDs or numeric IDs
+  [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file'], // Uploaded files with extensions
   
   // Custom patterns
   [/\/users\/\d+/, '/users/:id'],                                   // /users/123

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ module.exports = {
       
       // 🎯 Path Normalization Rules
       normalize: [
-        [/\/[a-z0-9]{24,25}|\d+/, '/:id'], // Document IDs or numeric IDs
+        [/\/(?:[a-z0-9]{24,25}|\d+)(?=\/|$)/, '/:id'], // Document IDs or numeric IDs
         [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file'], // Uploaded files with extensions
       ]
     }
@@ -156,7 +156,7 @@ Use an array of `[RegExp, replacement]` tuples to define normalization patterns:
 
 ```js
 normalize: [
-  [/[a-z0-9]{24,25}|\d/, ':id'], // Document IDs or numeric IDs
+  [/\/(?:[a-z0-9]{24,25}|\d+)(?=\/|$)/, '/:id'], // Document IDs or numeric IDs
   [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file'], // Uploaded files with extensions
   
   // Custom patterns

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A powerful middleware plugin that adds comprehensive Prometheus metrics to your 
 - 📊 **Database Lifecycle Tracking** - Monitor Strapi lifecycle events (create, update, delete) duration ⚡
 - 🔌 **Easy Integration** - Simple configuration with sensible defaults - get started in minutes!
 - 🆔 **Version Tracking** - Monitor Strapi version information for deployment tracking
-- 🎯 **Smart Path Normalization** - Automatically converts `/api/users/123` to `/api/users/:id` for better metric cardinality
+- 🎯 **Smart Path Normalization** - Flexible normalization with regex patterns or custom functions to group similar routes for better metric cardinality 📊
 - 📦 **TypeScript Support** - Built with TypeScript for better developer experience
 
 ## ⚡ Installation
@@ -68,9 +68,28 @@ module.exports = {
         port: 9000,           // Metrics server port
         host: '0.0.0.0',      // Metrics server host
         path: '/metrics'      // Metrics endpoint path
-      }
+      },
       // OR disable separate server (use with caution):
       // server: false
+      
+      // 🎯 Path Normalization Rules
+      normalize: [
+        // Strapi API routes
+        [/^\/api\/([^\/]+)\/([^\/]+)$/, '/api/$1/:id'],                    // /api/posts/123
+        [/^\/api\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/api/$1/:id/$3'],       // /api/posts/123/comments
+        [/^\/api\/([^\/]+)\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/api/$1/$2/:id/$4'], // /api/posts/123/comments/456
+        
+        // i18n locale routes
+        [/^\/([a-z]{2}(-[A-Z]{2})?)\/api\/([^\/]+)\/([^\/]+)$/, '/$1/api/$3/:id'],
+        [/^\/([a-z]{2}(-[A-Z]{2})?)\//, '/:locale/'],
+        
+        // Admin routes
+        [/^\/admin\/content-manager\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/admin/content-manager/$1/:contentType/:id'],
+        [/^\/admin\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/admin/$1/:type/:id'],
+        
+        // Upload routes
+        [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file']
+      ]
     }
   }
 };
@@ -93,6 +112,18 @@ export default {
         port: parseInt(process.env.METRICS_PORT || '9000'),
         host: process.env.METRICS_HOST || '0.0.0.0',
         path: '/metrics'
+      },
+      
+      // Custom normalization function (alternative to array rules)
+      normalize: (ctx) => {
+        let path = ctx.path;
+        
+        // Custom logic for your specific needs
+        if (path.startsWith('/api/')) {
+          path = path.replace(/\/\d+/g, '/:id'); // Replace numeric IDs
+        }
+        
+        return path;
       }
     }
   }
@@ -123,6 +154,80 @@ When `collectDefaultMetrics` is enabled, you'll also get Node.js process metrics
 - `nodejs_heap_size_used_bytes` - Used heap size
 - `nodejs_external_memory_bytes` - External memory usage
 - And more...
+
+## 🎯 Smart Path Normalization
+
+The plugin features intelligent path normalization to ensure optimal metric cardinality by grouping similar routes together ✨
+
+### 📝 Configuration Options
+
+You can configure path normalization in two ways:
+
+#### 1. **Array of Regex Rules** (Recommended)
+
+Use an array of `[RegExp, replacement]` tuples to define normalization patterns:
+
+```js
+normalize: [
+  // Strapi API routes
+  [/^\/api\/([^\/]+)\/([^\/]+)$/, '/api/$1/:id'],                    // /api/posts/123
+  [/^\/api\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/api/$1/:id/$3'],       // /api/posts/123/comments
+  
+  // Admin routes
+  [/^\/admin\/content-manager\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/admin/content-manager/$1/:contentType/:id'],
+  
+  // Upload routes
+  [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file'],
+  
+  // Custom patterns
+  [/\/users\/\d+/, '/users/:id'],                                   // /users/123
+  [/\/orders\/ORD\d+/, '/orders/:orderCode']                        // /orders/ORD12345
+]
+```
+
+#### 2. **Custom Function**
+
+Use a function for dynamic normalization logic:
+
+```js
+normalize: (ctx) => {
+  let path = ctx.path;
+  
+  // Custom normalization logic
+  if (path.startsWith('/api/')) {
+    path = path.replace(/\/\d+/g, '/:id');           // Replace numeric IDs
+    path = path.replace(/\/[a-f0-9-]{36}/gi, '/:uuid'); // Replace UUIDs
+  }
+  
+  // Multi-tenant example
+  if (path.startsWith('/tenant/')) {
+    path = path.replace(/^\/tenant\/[^\/]+/, '/tenant/:id');
+  }
+  
+  return path;
+}
+```
+
+### 🏷️ Built-in Patterns
+
+The plugin includes pre-configured patterns for common Strapi routes:
+
+| Original Path | Normalized Path | Description |
+|--------------|----------------|-------------|
+| `/api/posts/123` | `/api/posts/:id` | API resource with ID |
+| `/api/posts/123/comments/456` | `/api/posts/:id/comments/:id` | Nested resources |
+| `/admin/content-manager/collection-types/api::post.post/123` | `/admin/content-manager/:type/:contentType/:id` | Admin content manager |
+| `/uploads/image.jpg` | `/uploads/:file` | File uploads |
+| `/en/api/posts/123` | `/:locale/api/posts/:id` | i18n localized routes |
+| `/fr-FR/dashboard` | `/:locale/dashboard` | Locale-specific pages |
+
+### 🚀 Benefits
+
+- ✅ **Low Cardinality** - Groups similar routes to prevent metric explosion
+- ✅ **Prometheus-Friendly** - Follows Prometheus best practices
+- ✅ **Flexible** - Support both regex patterns and custom functions  
+- ✅ **Performance** - Efficient pattern matching with minimal overhead
+- ✅ **Strapi-Aware** - Built-in knowledge of Strapi routing conventions
 
 ## 🚀 Quick Start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strapi-prometheus",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-prometheus",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "devDependencies": {
         "@strapi/sdk-plugin": "^5.2.6",

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -20,19 +20,8 @@ export interface Config {
 export default {
   default: {
     normalize: [
-      [/^\/api\/([^\/]+)\/([^\/]+)$/, '/api/$1/:id'], // /api/posts/123
-      [/^\/api\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/api/$1/:id/$3'], // /api/posts/123/comments
-      [/^\/api\/([^\/]+)\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/api/$1/$2/:id/$4'], // /api/posts/123/comments/456
-
-      // i18n locale routes (preserve locale but normalize what follows)
-      [/^\/([a-z]{2}(-[A-Z]{2})?)\/api\/([^\/]+)\/([^\/]+)$/, '/$1/api/$3/:id'],
-      [/^\/([a-z]{2}(-[A-Z]{2})?)\//, '/:locale/'],
-
-      // Admin routes with complex patterns
-      [/^\/admin\/content-manager\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/admin/content-manager/$1/:contentType/:id'],
-      [/^\/admin\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/admin/$1/:type/:id'],
-
-      [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file'],
+      [/\/[a-z0-9]{24,25}|\d/, '/:id'], // Document IDs or numeric IDs
+      [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file'], // Uploaded files with extensions
     ] as PathNormalizationRule[],
     collectDefaultMetrics: { prefix: '' },
     labels: [],

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -20,7 +20,7 @@ export interface Config {
 export default {
   default: {
     normalize: [
-      [/\/[a-z0-9]{24,25}|\d/, '/:id'], // Document IDs or numeric IDs
+      [/\/[a-z0-9]{24,25}|\d+/, '/:id'], // Document IDs or numeric IDs
       [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file'], // Uploaded files with extensions
     ] as PathNormalizationRule[],
     collectDefaultMetrics: { prefix: '' },

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -20,7 +20,7 @@ export interface Config {
 export default {
   default: {
     normalize: [
-      [/\/[a-z0-9]{24,25}|\d+/, '/:id'], // Document IDs or numeric IDs
+      [/\/(?:[a-z0-9]{24,25}|\d+)(?=\/|$)/, '/:id'], // Document IDs or numeric IDs
       [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file'], // Uploaded files with extensions
     ] as PathNormalizationRule[],
     collectDefaultMetrics: { prefix: '' },

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -1,13 +1,39 @@
 import { DefaultMetricsCollectorConfiguration, RegistryContentType } from "prom-client";
+import { Context } from "koa";
+
+export type PathNormalizationRule = [RegExp, string];
+
+/**
+ * Normalization configuration can be:
+ * - Array of normalization rules (tuples of [RegExp, string])
+ * - Function that takes context and returns either a normalized string
+ */
+export type NormalizationConfig = PathNormalizationRule[] | ((ctx: Context) => string);
 
 export interface Config {
   labels: object;
-  collectDefaultMetrics: false | DefaultMetricsCollectorConfiguration<RegistryContentType>
-  server: false | { port: number, host: string, path: string }
+  collectDefaultMetrics: false | DefaultMetricsCollectorConfiguration<RegistryContentType>;
+  server: false | { port: number, host: string, path: string };
+  normalize: NormalizationConfig;
 }
 
 export default {
   default: {
+    normalize: [
+      [/^\/api\/([^\/]+)\/([^\/]+)$/, '/api/$1/:id'], // /api/posts/123
+      [/^\/api\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/api/$1/:id/$3'], // /api/posts/123/comments
+      [/^\/api\/([^\/]+)\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/api/$1/$2/:id/$4'], // /api/posts/123/comments/456
+
+      // i18n locale routes (preserve locale but normalize what follows)
+      [/^\/([a-z]{2}(-[A-Z]{2})?)\/api\/([^\/]+)\/([^\/]+)$/, '/$1/api/$3/:id'],
+      [/^\/([a-z]{2}(-[A-Z]{2})?)\//, '/:locale/'],
+
+      // Admin routes with complex patterns
+      [/^\/admin\/content-manager\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/admin/content-manager/$1/:contentType/:id'],
+      [/^\/admin\/([^\/]+)\/([^\/]+)\/([^\/]+)$/, '/admin/$1/:type/:id'],
+
+      [/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file'],
+    ] as PathNormalizationRule[],
     collectDefaultMetrics: { prefix: '' },
     labels: [],
     server: {

--- a/server/src/middlewares/metrics.ts
+++ b/server/src/middlewares/metrics.ts
@@ -51,8 +51,10 @@ export default async (ctx: Context, next) => {
   const config: NormalizationConfig = strapi.plugin('prometheus').config('normalize');
 
   let route = ctx.path;
-  if (Array.isArray(config)) route = normalizePath(ctx.path, config);
-  else if (typeof config === 'function') route = config.call(null, ctx);
+  if (config) {
+    if (Array.isArray(config)) route = normalizePath(ctx.path, config);
+    else if (typeof config === 'function') route = config.call(null, ctx);
+  }
 
   const end = requestDurationSeconds.startTimer();
 

--- a/server/src/middlewares/metrics.ts
+++ b/server/src/middlewares/metrics.ts
@@ -1,4 +1,6 @@
-import { Counter, exponentialBuckets, Gauge, Histogram } from "prom-client";
+import { exponentialBuckets, Histogram } from "prom-client";
+import { Context } from "koa";
+import { NormalizationConfig, PathNormalizationRule } from "src/config";
 
 const requestDurationSeconds = new Histogram({
   name: 'http_request_duration_seconds',
@@ -33,36 +35,23 @@ const responseContentLengthBytes = new Histogram({
   buckets: exponentialBuckets(1024, 2, 20) // Buckets starting from 1 KB to 1 GB (1024 * 2^19 = ~536 MB, 2^20 = ~1 GB)
 });
 
-function getRoutePattern(ctx: any): string {
-  // First try the matched route (available after routing)
-  if (ctx._matchedRoute) {
-    return ctx._matchedRoute;
-  }
-
-  // Fallback to normalized path
-  return normalizePath(ctx.path);
-}
-
 /**
  * Normalize path to reduce metric cardinality when matched route isn't available
  */
-function normalizePath(path: string): string {
-  return path
-    // Strapi API routes: /api/articles/123 -> /api/articles/:id
-    .replace(/\/api\/([^\/]+)\/\d+(?:\/.*)?$/, '/api/$1/:id')
-    // Generic numeric IDs
-    .replace(/\/\d+/g, '/:id')
-    // UUIDs
-    .replace(/\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '/:uuid')
-    // File uploads
-    .replace(/\/uploads\/[^\/]+\.[a-zA-Z0-9]+/, '/uploads/:file')
-    // Clean up
-    .replace(/\/+/g, '/')
-    .replace(/\/$/, '') || '/';
+function normalizePath(path: string, rules: PathNormalizationRule[]): string {
+  for (const [regex, replacement] of rules) {
+    path = path.replace(regex, replacement);
+  }
+
+  return path;
 }
 
 
-export default async (ctx, next) => {
+export default async (ctx: Context, next) => {
+  const config: NormalizationConfig = strapi.plugin('prometheus').config('normalize');
+
+  const route = Array.isArray(config) ? normalizePath(ctx.path, config) : config.call(null, ctx);
+
   const end = requestDurationSeconds.startTimer();
 
   await next();
@@ -70,7 +59,7 @@ export default async (ctx, next) => {
   // Create final labels with all information
   const labels = {
     method: ctx.method,
-    route: getRoutePattern(ctx),
+    route,
     origin: ctx.origin || 'unknown',
     status: ctx.status
   };

--- a/server/src/middlewares/metrics.ts
+++ b/server/src/middlewares/metrics.ts
@@ -50,7 +50,9 @@ function normalizePath(path: string, rules: PathNormalizationRule[]): string {
 export default async (ctx: Context, next) => {
   const config: NormalizationConfig = strapi.plugin('prometheus').config('normalize');
 
-  const route = Array.isArray(config) ? normalizePath(ctx.path, config) : config.call(null, ctx);
+  let route = ctx.path;
+  if (Array.isArray(config)) route = normalizePath(ctx.path, config);
+  else if (typeof config === 'function') route = config.call(null, ctx);
 
   const end = requestDurationSeconds.startTimer();
 

--- a/yalc.lock
+++ b/yalc.lock
@@ -1,8 +1,0 @@
-{
-  "version": "v1",
-  "packages": {
-    "strapi-prometheus": {
-      "signature": "a3989320ed35c0cc6d45ead4bed62a8b"
-    }
-  }
-}


### PR DESCRIPTION
Introduces configurable route normalization via regex rules or custom functions to optimize metric cardinality and improve Prometheus integration. Updates docs to explain normalization options and benefits.