### PR TITLE
feat: remove origin label

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ The plugin automatically collects the following metrics with intelligent route p
 
 | Metric Name | Description | Type | Labels |
 |-------------|-------------|------|--------|
-| `http_request_duration_seconds` | Duration of HTTP requests in seconds ⏱️ | Histogram | `origin`, `method`, `route`, `status` |
-| `http_request_content_length_bytes` | Size of request payloads in bytes 📤 | Histogram | `origin`, `method`, `route`, `status` |
-| `http_response_content_length_bytes` | Size of response payloads in bytes 📥 | Histogram | `origin`, `method`, `route`, `status` |
+| `http_request_duration_seconds` | Duration of HTTP requests in seconds ⏱️ | Histogram | `method`, `route`, `status` |
+| `http_request_content_length_bytes` | Size of request payloads in bytes 📤 | Histogram | `method`, `route`, `status` |
+| `http_response_content_length_bytes` | Size of response payloads in bytes 📥 | Histogram | `method`, `route`, `status` |
 | `strapi_version_info` | Strapi version information 🏷️ | Gauge | `version` |
 | `lifecycle_duration_seconds` | Duration of Strapi database lifecycle events 💾 | Histogram | `event` |
 
@@ -371,7 +371,6 @@ module.exports = {
 - **Smart route detection** - Uses `_matchedRoute` when available for accurate patterns
 - **Consistent normalization** - `/api/articles/123` → `/api/articles/:id`
 - **Low cardinality** - Prevents metric explosion from dynamic paths
-- **Added `origin` label** - Track requests by source
 
 ### 🔄 Migration Steps
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-prometheus",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "A powerful Strapi plugin that adds comprehensive Prometheus metrics to monitor your API performance, system resources, and application behavior using prom-client.",
   "keywords": [
     "strapi",

--- a/server/src/middlewares/metrics.ts
+++ b/server/src/middlewares/metrics.ts
@@ -5,7 +5,7 @@ import { NormalizationConfig, PathNormalizationRule } from "src/config";
 const requestDurationSeconds = new Histogram({
   name: 'http_request_duration_seconds',
   help: 'Duration of HTTP requests in seconds',
-  labelNames: ['origin', 'method', 'route', 'status'],
+  labelNames: ['method', 'route', 'status'],
   buckets: [
     0.001, // 1 ms
     0.005, // 5 ms
@@ -24,14 +24,14 @@ const requestDurationSeconds = new Histogram({
 const requestContentLengthBytes = new Histogram({
   name: 'http_request_content_length_bytes',
   help: 'Histogram of the size of payloads sent to the server, measured in bytes.',
-  labelNames: ['origin', 'method', 'route', 'status'],
+  labelNames: ['method', 'route', 'status'],
   buckets: exponentialBuckets(1024, 2, 20) // Buckets starting from 1 KB to 1 GB (1024 * 2^19 = ~536 MB, 2^20 = ~1 GB)
 });
 
 const responseContentLengthBytes = new Histogram({
   name: 'http_response_content_length_bytes',
   help: 'Histogram of the size of payloads sent by the server, measured in bytes.',
-  labelNames: ['origin', 'method', 'route', 'status'],
+  labelNames: ['method', 'route', 'status'],
   buckets: exponentialBuckets(1024, 2, 20) // Buckets starting from 1 KB to 1 GB (1024 * 2^19 = ~536 MB, 2^20 = ~1 GB)
 });
 
@@ -64,7 +64,6 @@ export default async (ctx: Context, next) => {
   const labels = {
     method: ctx.method,
     route,
-    origin: ctx.origin || 'unknown',
     status: ctx.status
   };
 


### PR DESCRIPTION
remove origin label from all http related metrics to reduce the amount of data stored.